### PR TITLE
charts/haproxy: do not strip newlines in configmap, haproxy doesn't like this

### DIFF
--- a/charts/haproxy/Chart.yaml
+++ b/charts/haproxy/Chart.yaml
@@ -26,7 +26,7 @@ sources: [https://github.com/eMAGTechLabs/helm-charts/tree/master/charts/haproxy
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/haproxy/templates/configmap.yaml
+++ b/charts/haproxy/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
   {{- include "haproxy.labels" . | nindent 4 }}
 data:
 {{- range $key, $value := .Values.configFiles }}
-  {{ $key }}: |-
+  {{ $key }}: |
   {{ $value | default "" | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
fix for:
```
[WARNING] 237/153750 (1) : parsing [/usr/local/etc/haproxy/defaults.cfg:11]: Missing LF on last line, file might have been truncated at position 15. This will become a hard error in HAProxy 2.3.
[WARNING] 237/153750 (1) : parsing [/usr/local/etc/haproxy/global.cfg:6]: Missing LF on last line, file might have been truncated at position 13. This will become a hard error in HAProxy 2.3.
[WARNING] 237/153750 (1) : parsing [/usr/local/etc/haproxy/metrics.cfg:12]: Missing LF on last line, file might have been truncated at position 27. This will become a hard error in HAProxy 2.3.
```